### PR TITLE
feat: add mod help

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -19,5 +19,6 @@ These commands are locked to moderators.
 
 - `close`: This command will close (delete) the channel it is used in, as long as that channel was created with the `private` command (channel name starts with "private-").
 - `kick <username> <reason>`: This command kicks the `username` from the room it was called in. The command will log the action to the log channel, and send a DM to the user informing them of the `reason` for the kick.
+- `modHelp`: This command returns a list of the bot's available moderation commands.
 - `private <username>`: This command will create a new private room with the `username` user and all members of the moderator team.
 - `warn <username> <reason>`: This command sends a DM warning the `username` user for the given `reason`. The bot will send a log to the provided log channel.

--- a/src/commands/_CommandHandler.ts
+++ b/src/commands/_CommandHandler.ts
@@ -43,5 +43,9 @@ export const CommandHandler = async (
         return;
       }
     }
+    await driver.sendToRoom(
+      `I am sorry, but \`${commandName}\` is not a valid command.`,
+      roomName
+    );
   }
 };

--- a/src/commands/_CommandList.ts
+++ b/src/commands/_CommandList.ts
@@ -5,6 +5,7 @@ import { coc } from "./coc";
 import { eightball } from "./eightball";
 import { help } from "./help";
 import { kick } from "./kick";
+import { modHelp } from "./modHelp";
 import { priv } from "./private";
 import { quote } from "./quote";
 import { resources } from "./resources";
@@ -25,4 +26,5 @@ export const CommandList: CommandInt[] = [
   eightball,
   algo,
   kick,
+  modHelp,
 ];

--- a/src/commands/algo.ts
+++ b/src/commands/algo.ts
@@ -5,6 +5,7 @@ import { CommandInt } from "../interfaces/CommandInt";
 export const algo: CommandInt = {
   name: "algo",
   description: "Returns a random freeCodeCamp algorithm challenge.",
+  modCommand: false,
   command: async (_, room) => {
     const randomSuper = Math.floor(Math.random() * algorithmSlugs.length);
     const selectedSuper = algorithmSlugs[randomSuper];

--- a/src/commands/close.ts
+++ b/src/commands/close.ts
@@ -7,6 +7,7 @@ import { CommandInt } from "../interfaces/CommandInt";
 export const close: CommandInt = {
   name: "close",
   description: "Closes a channel created with the private command.",
+  modCommand: true,
   command: async (message, room, BOT): Promise<void> => {
     /**
      * While this should not be possible (it is confirmed

--- a/src/commands/coc.ts
+++ b/src/commands/coc.ts
@@ -4,6 +4,7 @@ import { CommandInt } from "../interfaces/CommandInt";
 export const coc: CommandInt = {
   name: "coc",
   description: "Returns information on the Code of Conduct.",
+  modCommand: false,
   command: async (_message, room) => {
     const codeOfConduct = `*freeCodeCamp Code of Conduct*
 These are the basic rules for interacting with the FreeCodeCamp community on any platform, including this chat server. You can read the full document on the [FreeCodeCamp article](https://freecodecamp.org/news/code-of-conduct).

--- a/src/commands/eightball.ts
+++ b/src/commands/eightball.ts
@@ -4,6 +4,7 @@ import { CommandInt } from "../interfaces/CommandInt";
 export const eightball: CommandInt = {
   name: "eightball",
   description: "Answers your question with a Magic Eightball phrase.",
+  modCommand: false,
   command: async (_, room) => {
     const options = [
       "As I see it, yes.",

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -5,8 +5,9 @@ import { CommandList } from "./_CommandList";
 export const help: CommandInt = {
   name: "help",
   description: "Returns information on the bot's list of commands.",
+  modCommand: false,
   command: async (_message, room) => {
-    const commands = CommandList.map(
+    const commands = CommandList.filter((command) => !command.modCommand).map(
       (command) => `\`${command.name}\`: ${command.description}`
     );
     const response = `Hello! I am a chat bot created specifically for this server! I have a few commands available - here is the information on those commands:\n${commands

--- a/src/commands/kick.ts
+++ b/src/commands/kick.ts
@@ -7,6 +7,7 @@ import { CommandInt } from "../interfaces/CommandInt";
 export const kick: CommandInt = {
   name: "kick",
   description: "Kicks a user from the room.",
+  modCommand: true,
   command: async (message, room, BOT) => {
     if (!message.u) {
       return;

--- a/src/commands/kick.ts
+++ b/src/commands/kick.ts
@@ -17,7 +17,17 @@ export const kick: CommandInt = {
       return;
     }
 
-    const [target, ...reason] = message.msg.split(" ").slice(2);
+    const [target, ...reasonArgs] = message.msg.split(" ").slice(2);
+
+    const reason = reasonArgs.join(" ");
+
+    if (!reason) {
+      await driver.sendToRoom(
+        "Sorry, but would you please provide the reason for taking this action?",
+        room
+      );
+      return;
+    }
 
     const isMod = await isModerator(message.u.username, BOT);
 
@@ -42,23 +52,17 @@ export const kick: CommandInt = {
       roomId: roomInfoRequest.room._id,
     });
 
-    if (!didKick.success) {
+    if (!didKick || !didKick.success) {
       await driver.sendToRoom("Sorry, but I cannot do that right now.", room);
       return;
     }
 
-    const notice = `${
-      message.u.username
-    } has kicked you from the #${room} for:\n${reason.join(
-      " "
-    )}\nPlease remember to follow our [code of conduct](https://freecodecamp.org/news/code-of-conduct).`;
+    const notice = `${message.u.username} has kicked you from #${room} for:\n${reason}\nPlease remember to follow our [code of conduct](https://freecodecamp.org/news/code-of-conduct).`;
 
     await driver.sendDirectToUser(notice, target);
 
     await sendToLog(
-      `${
-        message.u.username
-      } has kicked ${target} from #${room} for: ${reason.join(" ")}`,
+      `${message.u.username} has kicked ${target} from #${room} for: ${reason}`,
       BOT
     );
   },

--- a/src/commands/modHelp.ts
+++ b/src/commands/modHelp.ts
@@ -1,0 +1,30 @@
+import { driver } from "@rocket.chat/sdk";
+import { isModerator } from "../helpers/isModerator";
+import { CommandInt } from "../interfaces/CommandInt";
+import { CommandList } from "./_CommandList";
+
+export const modHelp: CommandInt = {
+  name: "modHelp",
+  description: "Returns information on the bot's list of moderation commands.",
+  modCommand: true,
+  command: async (message, room, BOT) => {
+    if (!message.u) {
+      return;
+    }
+    const isMod = await isModerator(message.u.username, BOT);
+    if (!isMod) {
+      await driver.sendToRoom(
+        "Sorry, but this command is restricted to moderators.",
+        room
+      );
+      return;
+    }
+    const commands = CommandList.filter((command) => command.modCommand).map(
+      (command) => `\`${command.name}\`: ${command.description}`
+    );
+    const response = `Here are my available moderation commands:\n${commands
+      .sort()
+      .join("\n")}`;
+    await driver.sendToRoom(response, room);
+  },
+};

--- a/src/commands/private.ts
+++ b/src/commands/private.ts
@@ -8,6 +8,7 @@ import { CommandInt } from "../interfaces/CommandInt";
 export const priv: CommandInt = {
   name: "private",
   description: "Creates a private room with a user and the moderator team",
+  modCommand: true,
   command: async (message, room, BOT) => {
     /**
      * While this should not be possible (it is confirmed

--- a/src/commands/quote.ts
+++ b/src/commands/quote.ts
@@ -5,6 +5,7 @@ import { CommandInt } from "../interfaces/CommandInt";
 export const quote: CommandInt = {
   name: "quote",
   description: "Returns a quote from the freeCodeCamp repository.",
+  modCommand: false,
   command: async (_message, room) => {
     const randomIndex = Math.floor(
       Math.random() * quotes.motivationalQuotes.length

--- a/src/commands/resources.ts
+++ b/src/commands/resources.ts
@@ -4,6 +4,7 @@ import { CommandInt } from "../interfaces/CommandInt";
 export const resources: CommandInt = {
   name: "resources",
   description: "Returns a list of helpful links",
+  modCommand: false,
   command: async (_message, room) => {
     const coc =
       "[freeCodeCamp Code of Conduct](https://freecodecamp.org/news/code-of-conduct) - The set of rules we apply to all of our community platforms.";

--- a/src/commands/warn.ts
+++ b/src/commands/warn.ts
@@ -29,16 +29,24 @@ export const warn: CommandInt = {
     }
 
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    const [target, ...reason] = message.msg!.split(" ").slice(2);
+    const [target, ...reasonArgs] = message.msg!.split(" ").slice(2);
 
-    const warning = `${message.u.username} has warned you for:\n${reason.join(
-      " "
-    )}.\nPlease remember to follow our Code of Conduct.`;
+    const reason = reasonArgs.join(" ");
+
+    if (!reason) {
+      await driver.sendToRoom(
+        "Sorry, but would you please provide the reason for this action?",
+        room
+      );
+      return;
+    }
+
+    const warning = `${message.u.username} has warned you for:\n${reason}.\nPlease remember to follow our [Code of Conduct](https://freecodecamp.org/news/code-of-conduct).`;
 
     await driver.sendDirectToUser(warning, target);
 
     await sendToLog(
-      `${message.u.username} warned ${target} for: ${reason.join(" ")}.`,
+      `${message.u.username} warned ${target} for: ${reason}.`,
       BOT
     );
   },

--- a/src/commands/warn.ts
+++ b/src/commands/warn.ts
@@ -6,6 +6,7 @@ import { CommandInt } from "../interfaces/CommandInt";
 export const warn: CommandInt = {
   name: "warn",
   description: "Issues a warning to a user. Restricted to moderators.",
+  modCommand: true,
   command: async (message, room, BOT) => {
     /**
      * While this should not be possible (it is confirmed

--- a/src/interfaces/CommandInt.ts
+++ b/src/interfaces/CommandInt.ts
@@ -4,6 +4,7 @@ import { BotInt } from "./BotInt";
 export interface CommandInt {
   name: string;
   description: string;
+  modCommand: boolean;
   /**
    * The function that executes when the command `name` is passed in the message.
    * @param {IMessage} message The message object to run the command against.


### PR DESCRIPTION
# Pull Request

<!--Before contributing, please read our contributing guidelines-->

## Description:

- Adds a `modHelp` command
- Separates the locked commands from the unlocked commands
- Each help command only returns the respective locked/unlocked commands
- Requires the reason field for `kick`/`warn` calls.

<!--A brief description of what your pull request does.--> 

## Related Issue:

<!--Is this related to an issue? Does it close one? If so, replace the XXXXX below with the issue number.-->

Closes #XXXXX
