### PR TITLE
feat: Add parameter to help commands

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,3 +11,12 @@
 <!--Is this related to an issue? Does it close one? If so, replace the XXXXX below with the issue number.-->
 
 Closes #XXXXX
+
+## Scope:
+
+Did you remember to update the `package.json` version number?
+
+- [ ] Major Version Update: X.\_.\_ (for complete code refactors, or large PRs that adjust most of the codebase)
+- [ ] Minor Version Update: \_.X.\_ (for the addition of new commands)
+- [ ] Patch Version Update: \_.\_.X (for command updates or bug fixes _in the code_.)
+- [ ] No Version Update: \_.\_.\_ (no version update for additions to tests, documentation, or anything that isn't end-user facing.)

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -9,7 +9,7 @@ These commands are available to all users.
 - `algo`: Returns a random freeCodeCamp algorithm challenge.
 - `coc`: Returns a brief version of the freeCodeCamp Code of Conduct, with a link to the full article.
 - `eightball`: Returns a response from a Magic 8-Ball toy.
-- `help`: Returns a list of the bot's available commands.
+- `help <?command>`: Returns a list of the bot's available commands, or a detailed description of the specific `command`.
 - `ping`: Returns a message with the bot's response time in milliseconds.
 - `quote`: Returns a random motivational quote from freeCodeCamp's curated list.
 - `resources`: Returns a list of helpful freeCodeCamp resources.
@@ -20,6 +20,6 @@ These commands are locked to moderators.
 
 - `close`: This command will close (delete) the channel it is used in, as long as that channel was created with the `private` command (channel name starts with "private-").
 - `kick <username> <reason>`: This command kicks the `username` from the room it was called in. The command will log the action to the log channel, and send a DM to the user informing them of the `reason` for the kick.
-- `modHelp`: This command returns a list of the bot's available moderation commands.
+- `modHelp <?command>`: This command returns a list of the bot's available moderation commands, or a detailed description of the specific `command`.
 - `private <username>`: This command will create a new private room with the `username` user and all members of the moderator team.
 - `warn <username> <reason>`: This command sends a DM warning the `username` user for the given `reason`. The bot will send a log to the provided log channel.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rocketchat-bot",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A test repository for building a rocket chat bot\"",
   "main": "./prod/index.ts",
   "scripts": {

--- a/src/commands/algo.ts
+++ b/src/commands/algo.ts
@@ -5,6 +5,10 @@ import { CommandInt } from "../interfaces/CommandInt";
 export const algo: CommandInt = {
   name: "algo",
   description: "Returns a random freeCodeCamp algorithm challenge.",
+  parameters: [],
+  usage: [
+    "`{prefix} algo` - Will return a random freeCodeCamp algorithm challenge.",
+  ],
   modCommand: false,
   command: async (_, room) => {
     const randomSuper = Math.floor(Math.random() * algorithmSlugs.length);

--- a/src/commands/close.ts
+++ b/src/commands/close.ts
@@ -7,6 +7,10 @@ import { CommandInt } from "../interfaces/CommandInt";
 export const close: CommandInt = {
   name: "close",
   description: "Closes a channel created with the private command.",
+  parameters: [],
+  usage: [
+    "`{prefix} close` - will close the channel this command is called in, as long as the channel name starts with `private-`.",
+  ],
   modCommand: true,
   command: async (message, room, BOT): Promise<void> => {
     /**

--- a/src/commands/coc.ts
+++ b/src/commands/coc.ts
@@ -4,6 +4,10 @@ import { CommandInt } from "../interfaces/CommandInt";
 export const coc: CommandInt = {
   name: "coc",
   description: "Returns information on the Code of Conduct.",
+  parameters: [],
+  usage: [
+    "`{prefix} coc` - will return a summarised version of the freeCodeCamp Code of Conduct.",
+  ],
   modCommand: false,
   command: async (_message, room) => {
     const codeOfConduct = `*freeCodeCamp Code of Conduct*

--- a/src/commands/eightball.ts
+++ b/src/commands/eightball.ts
@@ -4,6 +4,8 @@ import { CommandInt } from "../interfaces/CommandInt";
 export const eightball: CommandInt = {
   name: "eightball",
   description: "Answers your question with a Magic Eightball phrase.",
+  parameters: [],
+  usage: ["`{prefix} eightball` - will return a magic eightball response."],
   modCommand: false,
   command: async (_, room) => {
     const options = [

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -5,14 +5,49 @@ import { CommandList } from "./_CommandList";
 export const help: CommandInt = {
   name: "help",
   description: "Returns information on the bot's list of commands.",
+  parameters: ["?command"],
+  usage: [
+    "`{prefix} help` - will return a list of public commands",
+    "`{prefix} help ?command` - will return a detailed description of that command.",
+  ],
   modCommand: false,
-  command: async (_message, room, BOT) => {
-    const commands = CommandList.filter((command) => !command.modCommand).map(
+  command: async (message, room, BOT) => {
+    const commands = CommandList.filter((command) => !command.modCommand);
+
+    const commandList = commands.map(
       (command) => `\`${BOT.prefix} ${command.name}\`: ${command.description}`
     );
-    const response = `Hello! I am a chat bot created specifically for this server! I have a few commands available - here is the information on those commands:\n${commands
-      .sort()
-      .join("\n")}`;
+
+    const [query] = message.msg!.split(" ").slice(2);
+
+    if (!query) {
+      const response = `Hello! I am a chat bot created specifically for this server! I have a few commands available - here is the information on those commands:\n${commandList
+        .sort()
+        .join("\n")}`;
+      await driver.sendToRoom(response, room);
+      return;
+    }
+
+    const targetCommand = commands.find((el) => el.name === query);
+
+    if (!targetCommand) {
+      const response = `I am so sorry, but I do not have a public ${query} command.`;
+      await driver.sendToRoom(response, room);
+      return;
+    }
+
+    const response = `*Information on my \`${query}\` command:*
+_Description_
+${targetCommand.description}
+
+_Parameters_
+${targetCommand.parameters.length ? targetCommand.parameters.join(" ") : "none"}
+
+_Example Uses_
+${targetCommand.usage
+  .map((use) => use.replace(/\{prefix\}/g, BOT.prefix))
+  .join("\n")}`;
+
     await driver.sendToRoom(response, room);
   },
 };

--- a/src/commands/kick.ts
+++ b/src/commands/kick.ts
@@ -7,6 +7,10 @@ import { CommandInt } from "../interfaces/CommandInt";
 export const kick: CommandInt = {
   name: "kick",
   description: "Kicks a user from the room.",
+  parameters: ["user", "reason"],
+  usage: [
+    "`{prefix} kick user reason` - will kick the `user` from the room the command is called in, DM that `user` with the `reason` for the action, and log the action in the log channel.",
+  ],
   modCommand: true,
   command: async (message, room, BOT) => {
     if (!message.u) {

--- a/src/commands/modHelp.ts
+++ b/src/commands/modHelp.ts
@@ -6,25 +6,51 @@ import { CommandList } from "./_CommandList";
 export const modHelp: CommandInt = {
   name: "modHelp",
   description: "Returns information on the bot's list of moderation commands.",
+  parameters: ["?command"],
+  usage: [
+    "`{prefix} modHelp` - will return a list of moderator-only commands",
+    "`{prefix} modHelp ?command` - will return a detailed description of that command.",
+  ],
   modCommand: true,
   command: async (message, room, BOT) => {
-    if (!message.u) {
-      return;
-    }
-    const isMod = await isModerator(message.u.username, BOT);
-    if (!isMod) {
-      await driver.sendToRoom(
-        "Sorry, but this command is restricted to moderators.",
-        room
-      );
-      return;
-    }
-    const commands = CommandList.filter((command) => command.modCommand).map(
+    const commands = CommandList.filter((command) => command.modCommand);
+
+    const commandList = commands.map(
       (command) => `\`${BOT.prefix} ${command.name}\`: ${command.description}`
     );
-    const response = `Here are my available moderation commands:\n${commands
-      .sort()
-      .join("\n")}`;
+
+    const [query] = message.msg!.split(" ").slice(2);
+
+    if (!query) {
+      const response = `Here are my available moderation commands:\n${commandList
+        .sort()
+        .join("\n")}`;
+      await driver.sendToRoom(response, room);
+      return;
+    }
+
+    const targetCommand = commands.find((el) => el.name === query);
+
+    if (!targetCommand) {
+      const response = `I am so sorry, but I do not have a private ${query} command.`;
+      await driver.sendToRoom(response, room);
+      return;
+    }
+
+    const response = `*Information on my \`${query}\` command:*
+_Description_
+${targetCommand.description}
+
+_Parameters_
+${
+  targetCommand.parameters.length ? targetCommand.parameters.join(", ") : "none"
+}
+
+_Example Uses_
+${targetCommand.usage
+  .map((use) => use.replace(/\{prefix\}/g, BOT.prefix))
+  .join("\n")}`;
+
     await driver.sendToRoom(response, room);
   },
 };

--- a/src/commands/modHelp.ts
+++ b/src/commands/modHelp.ts
@@ -19,6 +19,15 @@ export const modHelp: CommandInt = {
       (command) => `\`${BOT.prefix} ${command.name}\`: ${command.description}`
     );
 
+    const isMod = await isModerator(message.u!.username, BOT);
+    if (!isMod) {
+      await driver.sendToRoom(
+        "Sorry, but this command is restricted to moderators.",
+        room
+      );
+      return;
+    }
+
     const [query] = message.msg!.split(" ").slice(2);
 
     if (!query) {

--- a/src/commands/ping.ts
+++ b/src/commands/ping.ts
@@ -4,6 +4,8 @@ import { CommandInt } from "../interfaces/CommandInt";
 export const ping: CommandInt = {
   name: "ping",
   description: "Returns a response from the bot with the ping time.",
+  parameters: [],
+  usage: ["`{prefix} ping` - will return the bot's current response time."],
   modCommand: false,
   command: async (_message, room) => {
     const start = Date.now();

--- a/src/commands/private.ts
+++ b/src/commands/private.ts
@@ -8,6 +8,10 @@ import { CommandInt } from "../interfaces/CommandInt";
 export const priv: CommandInt = {
   name: "private",
   description: "Creates a private room with a user and the moderator team",
+  parameters: ["user"],
+  usage: [
+    "`{prefix} private user` - will create a private channel, add the `user` to that channel, and add all moderators to the channel based on the configured moderator roles.",
+  ],
   modCommand: true,
   command: async (message, room, BOT) => {
     /**

--- a/src/commands/quote.ts
+++ b/src/commands/quote.ts
@@ -5,6 +5,10 @@ import { CommandInt } from "../interfaces/CommandInt";
 export const quote: CommandInt = {
   name: "quote",
   description: "Returns a quote from the freeCodeCamp repository.",
+  parameters: [],
+  usage: [
+    "`{prefix} quote` - will return a random quote from freeCodeCamp's curated list of motivational quotes/phrases.",
+  ],
   modCommand: false,
   command: async (_message, room) => {
     const randomIndex = Math.floor(

--- a/src/commands/resources.ts
+++ b/src/commands/resources.ts
@@ -4,6 +4,10 @@ import { CommandInt } from "../interfaces/CommandInt";
 export const resources: CommandInt = {
   name: "resources",
   description: "Returns a list of helpful links",
+  parameters: [],
+  usage: [
+    "`{prefix} resources` - will return links to the freeCodeCamp Code of Conduct, the Moderator Handbook, the Contributing Guidelines, the News Style Guide, and PRs ready for review.",
+  ],
   modCommand: false,
   command: async (_message, room) => {
     const coc =

--- a/src/commands/warn.ts
+++ b/src/commands/warn.ts
@@ -6,6 +6,10 @@ import { CommandInt } from "../interfaces/CommandInt";
 export const warn: CommandInt = {
   name: "warn",
   description: "Issues a warning to a user. Restricted to moderators.",
+  parameters: ["user", "reason"],
+  usage: [
+    "`{prefix} warn user reason` - will issue a DM warning to the `user` for the given `reason` and log the action in the log channel.",
+  ],
   modCommand: true,
   command: async (message, room, BOT) => {
     /**

--- a/src/interfaces/CommandInt.ts
+++ b/src/interfaces/CommandInt.ts
@@ -4,6 +4,8 @@ import { BotInt } from "./BotInt";
 export interface CommandInt {
   name: string;
   description: string;
+  parameters: string[];
+  usage: string[];
   modCommand: boolean;
   /**
    * The function that executes when the command `name` is passed in the message.


### PR DESCRIPTION
# Pull Request

<!--Before contributing, please read our contributing guidelines-->

## Description:

<!--A brief description of what your pull request does.--> 

Adds an optional `command` parameter to the help and modHelp commands. If an argument is given, the bot will respond with a detailed description of the provided command.

Signed-off-by: nhcarrigan <nhcarrigan@gmail.com>

## Related Issue:

<!--Is this related to an issue? Does it close one? If so, replace the XXXXX below with the issue number.-->

Closes #XXXXX
